### PR TITLE
update dockerfile to create continuous environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,28 @@
 FROM alpine:latest
 
-# add mono repo and mono
+# Install bash
+RUN apk add --no-cache bash
+
+# Add mono repo and mono
 RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
-# install requirements
+# Install requirements
 RUN  apk add --no-cache --upgrade ffmpeg mediainfo python3 git py3-pip python3-dev g++ cargo mktorrent rust
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 RUN pip3 install wheel
 
-WORKDIR Upload-Assistant
+WORKDIR UploadAssistant
 
-# install reqs
+# Install python requirements
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
-# copy everything
+# Copy everything
 COPY . .
 
-ENTRYPOINT ["python3", "/Upload-Assistant/upload.py"]
+# Set shell command alias
+RUN echo 'alias l4g="/UploadAssistant/upload.py"' >> /root/.bashrc
+
+# Start container and tail to keep container running
+CMD ["/bin/bash", "-c", "tail -f /dev/null"]


### PR DESCRIPTION
I updated the dockerfile with a mix of fixes and switch it to be a continuous environment that can be left running, instead of spinning up the container for each file. 

Changes:
- Install bash in the container instead of having just sh
- Set a venv for python to avoid errors about breaking system packages when trying to build the image
- Set the working directory to the same name as the repo
- clean up some of the comment wordings to be more verbose
- remove the old entrypoint
- and an alias of "l4g" that can be used instead of having to target the upload.pr file manually
- Set a command that starts bin/bash and tails the logs to null so that the container will stay running