### PR TITLE
don't add the episode title when specials are a full pack

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -2583,7 +2583,8 @@ class Prep():
 
             meta['episode_title_storage'] = guessit(video,{"excludes" : "part"}).get('episode_title', '')
             if meta['season'] == "S00" or meta['episode'] == "E00":
-                meta['episode_title'] = meta['episode_title_storage']
+                if meta['tv_pack'] == 0: # Only use the episode title when it isn't a full specials pack
+                    meta['episode_title'] = meta['episode_title_storage']
 
             # Guess the part of the episode (if available)
             meta['part'] = ""


### PR DESCRIPTION
I bloody found it. This resolves https://github.com/edge20200/UploadAssistant/issues/4 so that specials season packs don't try and use the title of the first episode in their name.