### PR TITLE
pass filename without path to guessit when getting tag

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -1601,7 +1601,7 @@ class Prep():
 
     def get_tag(self, video, meta):
         try:
-            tag = guessit(video)['release_group']
+            tag = guessit(os.path.basename(video))['release_group']
             tag = f"-{tag}"
         except:
             tag = ""


### PR DESCRIPTION
This resolves https://github.com/edge20200/UploadAssistant/issues/5

The script passes the file to guessit several times (opportunity to dry up that code in the future), as far as I know this is the only area that experiences an issue but passing the path name too, so I only fixed it here for now.